### PR TITLE
Group Elias Gamma SIMD with vbyte for short lists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 all:
-	g++ --std=c++14 -mavx2 -DCI_FORCEINLINE -O3 -Wall bin_to_jass.cpp compress_qmx.cpp compress_integer_elias_gamma_simd.cpp -o bin_to_jass
-	g++ --std=c++14 -mavx2 -DCI_FORCEINLINE -O3 -Wall bin_to_jass_disk.cpp compress_qmx.cpp compress_integer_elias_gamma_simd.cpp -o bin_to_jass_lowmemory
+	g++ --std=c++14 -mavx2 -DCI_FORCEINLINE -O3 -Wall bin_to_jass.cpp compress_qmx.cpp compress_integer_elias_gamma_simd.cpp compress_integer_elias_gamma_simd_vb.cpp compress_integer_variable_byte.cpp -o bin_to_jass
+	g++ --std=c++14 -mavx2 -DCI_FORCEINLINE -O3 -Wall bin_to_jass_disk.cpp compress_qmx.cpp compress_integer_elias_gamma_simd.cpp compress_integer_elias_gamma_simd_vb.cpp compress_integer_variable_byte.cpp -o bin_to_jass_lowmemory
 

--- a/bin_to_jass.cpp
+++ b/bin_to_jass.cpp
@@ -8,6 +8,7 @@
 #include <numeric>
 #include "compress_qmx.h"
 #include "compress_integer_elias_gamma_simd.h"
+#include "compress_integer_elias_gamma_simd_vb.h"
 #include <immintrin.h>
 
 
@@ -174,11 +175,13 @@ void score_index(std::string ds2i_prefix,
                  char compression){
 
 	  // Tell JASS that we're using QMX-D1: we need to compute our own deltas
-	  ANT_compress *compression_scheme;
+    ANT_compress *compression_scheme;
     if (compression == 'q')
         compression_scheme = new ANT_compress_qmx();
     else if (compression == 'G')
         compression_scheme = new JASS::compress_integer_elias_gamma_simd();
+    else if (compression == 'g')
+        compression_scheme = new JASS::compress_integer_elias_gamma_simd_vb();
     else
          compression_scheme = nullptr;
     ANT_compress &compressor = *compression_scheme;
@@ -414,7 +417,7 @@ void score_index(std::string ds2i_prefix,
 
 void usage(std::string program) {
   std::cerr << program << " <ds2i_prefix> <docid file> <lexicon file>" 
-            << "<max quantized score [256 = 8 bit quant, 512 = 9 bit quant]><q|G [QMX, EliasGammaSIMD]>\n";
+            << "<max quantized score [256 = 8 bit quant, 512 = 9 bit quant]><q|G|g [QMX, EliasGammaSIMD, EliasGammaSIMDvb]>\n";
   std::cerr << "e.g. " << program << " wsj wsj.documents wsj.terms 256 G\n";
   exit(EXIT_FAILURE);
 }
@@ -434,8 +437,10 @@ int main(int argc, char** argv)
     read_and_write_doclist(docid_file, "CIdoclist.bin");
     if (*argv[5] == 'q')
         score_index(ds2i_prefix, lexicon_file, quantization, 'q');
-	 else if (*argv[5] == 'G')
+    else if (*argv[5] == 'G')
         score_index(ds2i_prefix, lexicon_file, quantization, 'G');
+    else if (*argv[5] == 'g')
+        score_index(ds2i_prefix, lexicon_file, quantization, 'g');
     else
         usage(argv[0]);
 

--- a/bin_to_jass_disk.cpp
+++ b/bin_to_jass_disk.cpp
@@ -8,6 +8,7 @@
 #include <numeric>
 #include "compress_qmx.h"
 #include "compress_integer_elias_gamma_simd.h"
+#include "compress_integer_elias_gamma_simd_vb.h"
 #include <immintrin.h>
 
 
@@ -174,14 +175,16 @@ void score_index(std::string ds2i_prefix,
                  char compression){
 
 	 // Tell JASS that we're using QMX-D1: we need to compute our own deltas
-	 ANT_compress *compression_scheme;
-	if (compression == 'q')
-		 compression_scheme = new ANT_compress_qmx();
-	else if (compression == 'G')
-		 compression_scheme = new JASS::compress_integer_elias_gamma_simd();
-	else
-		  compression_scheme = nullptr;
-	ANT_compress &compressor = *compression_scheme;
+    ANT_compress *compression_scheme;
+    if (compression == 'q')
+        compression_scheme = new ANT_compress_qmx();
+    else if (compression == 'G')
+        compression_scheme = new JASS::compress_integer_elias_gamma_simd();
+    else if (compression == 'g')
+        compression_scheme = new JASS::compress_integer_elias_gamma_simd_vb();
+    else
+         compression_scheme = nullptr;
+    ANT_compress &compressor = *compression_scheme;
 
 
     uint32_t sse_alignment = 16;
@@ -441,10 +444,13 @@ int main(int argc, char** argv)
     read_and_write_doclist(docid_file, "CIdoclist.bin");
     if (*argv[5] == 'q')
         score_index(ds2i_prefix, lexicon_file, quantization, 'q');
-	 else if (*argv[5] == 'G')
+    else if (*argv[5] == 'G')
         score_index(ds2i_prefix, lexicon_file, quantization, 'G');
+    else if (*argv[5] == 'g')
+        score_index(ds2i_prefix, lexicon_file, quantization, 'g');
     else
         usage(argv[0]);
+
 
 return (EXIT_SUCCESS);
 }

--- a/compress.h
+++ b/compress.h
@@ -7,6 +7,9 @@
 
 #include <stdint.h>
 #define ANT_compressable_integer uint32_t
+#define integer uint32_t
+#define JASS_COMPRESS_INTEGER_BITS_PER_INTEGER 32
+
 /*
 	class ANT_COMPRESS
 	------------------

--- a/compress_integer_elias_gamma_simd_vb.cpp
+++ b/compress_integer_elias_gamma_simd_vb.cpp
@@ -1,0 +1,378 @@
+/*
+	COMPRESS_INTEGER_ELIAS_GAMMA_SIMD_VB.CPP
+	----------------------------------------
+	Copyright (c) 2018 Andrew Trotman
+	Released under the 2-clause BSD license (See:https://en.wikipedia.org/wiki/BSD_licenses)
+*/
+#include <string.h>
+#include <stdint.h>
+#include <immintrin.h>
+
+#include <vector>
+#include <iostream>
+
+//#include "maths.h"
+#include "compress_integer_elias_gamma_simd_vb.h"
+
+#define WORD_WIDTH 32
+#define WORDS (512 / WORD_WIDTH)
+
+namespace JASS
+	{
+	namespace maths
+		{
+		/*
+			MATHS_CEILING_LOG2_ANSWER[]
+			---------------------------
+		*/
+		/*!
+			@brief Lookup table to compute ceil(log2(x))
+		*/
+		static constexpr uint8_t maths_ceiling_log2_answer[0x100] =
+			{
+			0, 1, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4,
+			5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+			6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+			6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+			7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+			7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+			7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+			7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+			8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+			8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+			8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+			8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+			8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+			8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+			8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+			8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8
+			};
+		/*
+			MATHS::CEILING_LOG2()
+			---------------------
+		*/
+		/*!
+			@brief return the ceiling of log2(x)
+			@param x [in] the value to compute the log of.
+			@return ceiling(log2(x));
+		*/
+		template <typename TYPE>
+		static constexpr TYPE ceiling_log2(TYPE x)
+			{
+			/* coverity[BAD_SHIFT] */
+			/* coverity[CONSTANT_EXPRESSION_RESULT] */
+			return (static_cast<size_t>(x) >> 8 == 0) ?
+				maths_ceiling_log2_answer[x] :
+			(static_cast<size_t>(x) >> 16 == 0) ?
+				maths_ceiling_log2_answer[(static_cast<size_t>(x) >> 8) & 0xFF] + 8 :
+			(static_cast<size_t>(x) >> 24 == 0) ?
+				maths_ceiling_log2_answer[(static_cast<size_t>(x) >> 16) & 0xFF] + 16 :
+			(static_cast<size_t>(x) >> 32 == 0) ?
+				maths_ceiling_log2_answer[(static_cast<size_t>(x) >> 24) & 0xFF] + 24 :
+			(static_cast<size_t>(x) >> 40 == 0) ?
+				maths_ceiling_log2_answer[(static_cast<size_t>(x) >> 32) & 0xFF] + 32 :
+			(static_cast<size_t>(x) >> 48 == 0) ?
+				maths_ceiling_log2_answer[(static_cast<size_t>(x) >> 40) & 0xFF] + 40 :
+			(static_cast<size_t>(x) >> 56 == 0) ?
+				maths_ceiling_log2_answer[(static_cast<size_t>(x) >> 48) & 0xFF] + 48 :
+				maths_ceiling_log2_answer[(static_cast<size_t>(x) >> 56) & 0xFF] + 56;
+			}
+	}
+
+	/*
+		COMPRESS_INTEGER_ELIAS_GAMMA_SIMD_VB::COMPUTE_SELECTOR()
+		--------------------------------------------------------
+	*/
+	uint32_t compress_integer_elias_gamma_simd_vb::compute_selector(const uint8_t *encodings)
+		{
+		uint32_t value = 0;
+		int current;
+
+		for (current = 0; current < 32; current++)
+			if (encodings[current] == 0)
+				break;
+
+		/*
+			Compute the permutation number
+		*/
+		for (current--; current >=  0; current--)
+			{
+			size_t number_of_0s = encodings[current];
+			value <<= number_of_0s;
+			value |= 1 << (number_of_0s - 1);
+			}
+
+		return value;
+		}
+
+	/*
+		COMPRESS_INTEGER_ELIAS_GAMMA_SIMD_VB::ENCODE()
+		----------------------------------------------
+	*/
+	size_t compress_integer_elias_gamma_simd_vb::encode(void *encoded, size_t encoded_buffer_length, const integer *array, size_t elements)
+		{
+		uint8_t encodings[33] = {0};
+		uint32_t *destination = (uint32_t *)encoded;
+		uint32_t *end_of_destination = (uint32_t *)((uint8_t *)encoded + encoded_buffer_length);
+
+		/*
+			Store the length of the variable byte part
+		*/
+		*destination++ = 0;			// store as a 4-byte integer to start with (variable byte encode it later)
+		while (1)
+			{
+			/*
+				Check for overflow of the output buffer
+			*/
+			if (destination + WORDS + 1 + 1 > end_of_destination)
+				return 0;
+
+			/*
+				Zero the result memory before writing the bit paterns into it
+			*/
+			::memset(destination, 0, (WORDS + 1) * 4);
+
+			/*
+				Get the address of the selector and move on to the payload
+			*/
+			uint32_t *selector = destination;
+			destination++;
+
+			/*
+				Encode the next integer
+			*/
+			uint32_t remaining = WORD_WIDTH;
+			uint32_t cumulative_shift = 0;
+			const integer *array_at_start_of_codeword = array;
+			size_t elements_at_start_of_codeword = elements;
+
+			/*
+				Pack into the next word
+			*/
+			uint32_t slice;
+			for (slice = 0; slice < 32; slice++)
+				{
+				/*
+					Find the width of this column
+				*/
+				uint32_t max_width = 1;
+				for (uint32_t word = 0; word < WORDS; word++)
+					max_width |= word < elements ? array[word] : 1;
+
+				max_width = maths::ceiling_log2(max_width);
+
+				if (max_width > remaining)
+					break;			// move on to the next code word
+				else
+					{
+					/*
+						Pack them in because there's room
+					*/
+					encodings[slice] = max_width;
+					for (uint32_t word = 0; word < WORDS; word++)
+						destination[word] |= (word < elements ? array[word] : 0) << cumulative_shift;
+					cumulative_shift += max_width;
+					remaining -= max_width;
+
+					/*
+						Check for end of input
+					*/
+					if (WORDS >= elements)
+						{
+						/*
+							Pack the last selector
+						*/
+						encodings[slice] += remaining;
+						encodings[slice + 1] = 0;
+						*selector = compute_selector(encodings);
+
+						if (WORDS == elements)
+							{
+							uint32_t *vb_length_locaton = (uint32_t *)encoded;
+							*vb_length_locaton = 0;
+							return (uint8_t *)(destination + WORDS) - (uint8_t *)encoded;						// we've finished the encoding
+							}
+						else
+							{
+							/*
+								We're at end of input so either re-code the final column as variable byte or re-code the entire word.
+							*/
+
+							/*
+								Check to see how many bits of the current word we're using.
+							*/
+							size_t elias_size = WORDS * (WORD_WIDTH / 8);		// size (in bytes) of the codeword up to the last column
+							for (size_t current = 0; current < elements; current++)
+								elias_size += bytes_needed_for(array[current]);
+
+							/*
+								Check to see how much space it would take with variable byte
+							*/
+							size_t vbyte_size = 0;
+							for (size_t current = 0; current < elements_at_start_of_codeword; current++)
+								vbyte_size += bytes_needed_for(array_at_start_of_codeword[current]);
+
+							if (vbyte_size < elias_size)
+								{
+								// re-code the codeword
+								vbyte_size = compress_integer_variable_byte::encode(selector, end_of_destination - selector, array_at_start_of_codeword, elements_at_start_of_codeword);
+								destination = selector;
+								}
+							else
+								{
+								// re-code the final column
+								for (uint32_t word = 0; word < WORDS; word++)
+									destination[word] ^= (word < elements ? array[word] : 0) << (cumulative_shift - max_width);// becuase we've alread incremente cumulative_shift
+								destination += WORDS;
+								encodings[slice - 1] += encodings[slice];
+								encodings[slice] = 0;
+								*selector = compute_selector(encodings);
+								vbyte_size = compress_integer_variable_byte::encode(destination, end_of_destination - selector, array, elements);
+								}
+							uint32_t *vb_length_locaton = (uint32_t *)encoded;
+							*vb_length_locaton = vbyte_size;
+
+							return (uint8_t *)destination + vbyte_size - (uint8_t *)encoded;						// we've finished the encoding
+							}
+						}
+					elements -= WORDS;
+					array += WORDS;
+					}
+				}
+			/*
+				Didn't fit!  Finish this codeword by padding the last width to the full width of the block (i.e. add the spare bits)
+			*/
+			encodings[slice - 1] += remaining;
+			encodings[slice] = 0;
+
+			*selector = compute_selector(encodings);
+			destination += WORDS;
+			}
+
+		return 0;			// can't happen
+		}
+
+	alignas(64)  const uint32_t compress_integer_elias_gamma_simd_vb::mask_set[33][16]=
+		{
+		{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},								///< Sentinal as the selector cannot be 0.
+		{0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01},								///< AND mask for 1-bit integers
+		{0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03},								///< AND mask for 2-bit integers
+		{0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07},								///< AND mask for 3-bit integers
+		{0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f},								///< AND mask for 4-bit integers
+		{0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f},								///< AND mask for 5-bit integers
+		{0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f},								///< AND mask for 6-bit integers
+		{0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f},								///< AND mask for 7-bit integers
+		{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},								///< AND mask for 8-bit integers
+		{0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff},						///< AND mask for 9-bit integers
+		{0x3ff, 0x3ff, 0x3ff, 0x3ff, 0x3ff, 0x3ff, 0x3ff, 0x3ff, 0x3ff, 0x3ff, 0x3ff, 0x3ff, 0x3ff, 0x3ff, 0x3ff, 0x3ff},						///< AND mask for 10-bit integers
+		{0x7ff, 0x7ff, 0x7ff, 0x7ff, 0x7ff, 0x7ff, 0x7ff, 0x7ff, 0x7ff, 0x7ff, 0x7ff, 0x7ff, 0x7ff, 0x7ff, 0x7ff, 0x7ff},						///< AND mask for 11-bit integers
+		{0xfff, 0xfff, 0xfff, 0xfff, 0xfff, 0xfff, 0xfff, 0xfff, 0xfff, 0xfff, 0xfff, 0xfff, 0xfff, 0xfff, 0xfff, 0xfff},						///< AND mask for 12-bit integers
+		{0x1fff, 0x1fff, 0x1fff, 0x1fff, 0x1fff, 0x1fff, 0x1fff, 0x1fff, 0x1fff, 0x1fff, 0x1fff, 0x1fff, 0x1fff, 0x1fff, 0x1fff, 0x1fff},			///< AND mask for 13-bit integers
+		{0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff},			///< AND mask for 14-bit integers
+		{0x7fff, 0x7fff, 0x7fff, 0x7fff, 0x7fff, 0x7fff, 0x7fff, 0x7fff, 0x7fff, 0x7fff, 0x7fff, 0x7fff, 0x7fff, 0x7fff, 0x7fff, 0x7fff},			///< AND mask for 15-bit integers
+		{0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff},			///< AND mask for 16-bit integers
+		{0x1ffff, 0x1ffff, 0x1ffff, 0x1ffff, 0x1ffff, 0x1ffff, 0x1ffff, 0x1ffff, 0x1ffff, 0x1ffff, 0x1ffff, 0x1ffff, 0x1ffff, 0x1ffff, 0x1ffff, 0x1ffff},								///< AND mask for 17-bit integers
+		{0x3ffff, 0x3ffff, 0x3ffff, 0x3ffff, 0x3ffff, 0x3ffff, 0x3ffff, 0x3ffff, 0x3ffff, 0x3ffff, 0x3ffff, 0x3ffff, 0x3ffff, 0x3ffff, 0x3ffff, 0x3ffff},								///< AND mask for 18-bit integers
+		{0x7ffff, 0x7ffff, 0x7ffff, 0x7ffff, 0x7ffff, 0x7ffff, 0x7ffff, 0x7ffff, 0x7ffff, 0x7ffff, 0x7ffff, 0x7ffff, 0x7ffff, 0x7ffff, 0x7ffff, 0x7ffff},								///< AND mask for 19-bit integers
+		{0xfffff, 0xfffff, 0xfffff, 0xfffff, 0xfffff, 0xfffff, 0xfffff, 0xfffff, 0xfffff, 0xfffff, 0xfffff, 0xfffff, 0xfffff, 0xfffff, 0xfffff, 0xfffff},								///< AND mask for 20-bit integers
+		{0x1fffff, 0x1fffff, 0x1fffff, 0x1fffff, 0x1fffff, 0x1fffff, 0x1fffff, 0x1fffff, 0x1fffff, 0x1fffff, 0x1fffff, 0x1fffff, 0x1fffff, 0x1fffff, 0x1fffff, 0x1fffff},								///< AND mask for 21-bit integers
+		{0x3fffff, 0x3fffff, 0x3fffff, 0x3fffff, 0x3fffff, 0x3fffff, 0x3fffff, 0x3fffff, 0x3fffff, 0x3fffff, 0x3fffff, 0x3fffff, 0x3fffff, 0x3fffff, 0x3fffff, 0x3fffff},								///< AND mask for 22-bit integers
+		{0x7fffff, 0x7fffff, 0x7fffff, 0x7fffff, 0x7fffff, 0x7fffff, 0x7fffff, 0x7fffff, 0x7fffff, 0x7fffff, 0x7fffff, 0x7fffff, 0x7fffff, 0x7fffff, 0x7fffff, 0x7fffff},								///< AND mask for 23-bit integers
+		{0xffffff, 0xffffff, 0xffffff, 0xffffff, 0xffffff, 0xffffff, 0xffffff, 0xffffff, 0xffffff, 0xffffff, 0xffffff, 0xffffff, 0xffffff, 0xffffff, 0xffffff, 0xffffff},								///< AND mask for 24-bit integers
+		{0x1ffffff, 0x1ffffff, 0x1ffffff, 0x1ffffff, 0x1ffffff, 0x1ffffff, 0x1ffffff, 0x1ffffff, 0x1ffffff, 0x1ffffff, 0x1ffffff, 0x1ffffff, 0x1ffffff, 0x1ffffff, 0x1ffffff, 0x1ffffff},						///< AND mask for 25-bit integers
+		{0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff},						///< AND mask for 26-bit integers
+		{0x7ffffff, 0x7ffffff, 0x7ffffff, 0x7ffffff, 0x7ffffff, 0x7ffffff, 0x7ffffff, 0x7ffffff, 0x7ffffff, 0x7ffffff, 0x7ffffff, 0x7ffffff, 0x7ffffff, 0x7ffffff, 0x7ffffff, 0x7ffffff},						///< AND mask for 27-bit integers
+		{0xfffffff, 0xfffffff, 0xfffffff, 0xfffffff, 0xfffffff, 0xfffffff, 0xfffffff, 0xfffffff, 0xfffffff, 0xfffffff, 0xfffffff, 0xfffffff, 0xfffffff, 0xfffffff, 0xfffffff, 0xfffffff},						///< AND mask for 28-bit integers
+		{0x1fffffff, 0x1fffffff, 0x1fffffff, 0x1fffffff, 0x1fffffff, 0x1fffffff, 0x1fffffff, 0x1fffffff, 0x1fffffff, 0x1fffffff, 0x1fffffff, 0x1fffffff, 0x1fffffff, 0x1fffffff, 0x1fffffff, 0x1fffffff},			///< AND mask for 29-bit integers
+		{0x3fffffff, 0x3fffffff, 0x3fffffff, 0x3fffffff, 0x3fffffff, 0x3fffffff, 0x3fffffff, 0x3fffffff, 0x3fffffff, 0x3fffffff, 0x3fffffff, 0x3fffffff, 0x3fffffff, 0x3fffffff, 0x3fffffff, 0x3fffffff},			///< AND mask for 30-bit integers
+		{0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff},			///< AND mask for 31-bit integers
+		{0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff},			///< AND mask for 32-bit integers
+		};
+
+#ifdef __AVX512F__
+	/*
+		COMPRESS_INTEGER_ELIAS_GAMMA_SIMD_VB::DECODE()
+		----------------------------------------------
+	*/
+	void compress_integer_elias_gamma_simd_vb::decode(integer *decoded, size_t integers_to_decode, const void *source_as_void, size_t source_length)
+		{
+		__m512i mask;
+		const uint8_t *source = (const uint8_t *)source_as_void;
+		size_t vb_length = *(const uint32_t *)source_as_void;
+		const uint8_t *end_of_source = (const uint8_t *)source_as_void + source_length - vb_length;
+		source += sizeof(uint32_t);
+		__m512i *into = (__m512i *)decoded;
+		uint64_t selector = 0;
+		__m512i payload;
+
+		while (1)
+			{
+			if (selector == 0)
+				{
+				if (source >= end_of_source)
+					break;
+				selector = *(uint32_t *)source;
+				payload = _mm512_loadu_si512((__m256i *)(source + 4));
+				source += 68;
+				}
+
+			uint32_t width = (uint32_t)find_first_set_bit(selector);
+			mask = _mm512_loadu_si512((__m512i *)mask_set[width]);
+			_mm512_storeu_si512(into, _mm512_and_si512(payload, mask));
+			payload = _mm512_srli_epi32(payload, width);
+
+			into++;
+			selector >>= width;
+			}
+
+		if (vb_length != 0)
+			compress_integer_variable_byte::decode((integer *)into, vb_length, source, vb_length);
+		}
+
+
+#else
+	/*
+		COMPRESS_INTEGER_ELIAS_GAMMA_SIMD_VB::DECODE()
+		----------------------------------------------
+	*/
+	void compress_integer_elias_gamma_simd_vb::decode(integer *decoded, size_t integers_to_decode, const void *source_as_void, size_t source_length)
+		{
+		__m256i mask;
+		const uint8_t *source = (const uint8_t *)source_as_void;
+		size_t vb_length = *(const uint32_t *)source_as_void;
+		const uint8_t *end_of_source = (const uint8_t *)source_as_void + source_length - vb_length;
+		source += sizeof(uint32_t);
+		__m256i *into = (__m256i *)decoded;
+		uint64_t selector = 0;
+		__m256i payload1;
+		__m256i payload2;
+
+		while (1)
+			{
+			if (selector == 0)
+				{
+				if (source >= end_of_source)
+					break;
+				selector = *(uint32_t *)source;
+				payload1 = _mm256_loadu_si256((__m256i *)(source + 4));
+				payload2 = _mm256_loadu_si256((__m256i *)(source + 36));
+				source += 68;
+				}
+
+			uint32_t width = (uint32_t)find_first_set_bit(selector);
+			mask = _mm256_loadu_si256((__m256i *)mask_set[width]);
+			_mm256_storeu_si256(into, _mm256_and_si256(payload1, mask));
+			_mm256_storeu_si256(into + 1, _mm256_and_si256(payload2, mask));
+			payload1 = _mm256_srli_epi32(payload1, width);
+			payload2 = _mm256_srli_epi32(payload2, width);
+
+			into += 2;
+			selector >>= width;
+			}
+
+		if (vb_length != 0)
+			compress_integer_variable_byte::decode((integer *)into, vb_length, source, vb_length);
+		}
+
+#endif
+	}

--- a/compress_integer_elias_gamma_simd_vb.h
+++ b/compress_integer_elias_gamma_simd_vb.h
@@ -1,0 +1,103 @@
+/*
+	COMPRESS_INTEGER_ELIAS_GAMMA_SIMD_VB.H
+	--------------------------------------
+	Copyright (c) 2018 Andrew Trotman
+	Released under the 2-clause BSD license (See:https://en.wikipedia.org/wiki/BSD_licenses)
+*/
+/*!
+	@file
+	@brief Pack 32-bit integers into 512-bit SIMD words using elias gamma encoding - with VByte on short lists
+	@author Andrew Trotman
+	@copyright 2018 Andrew Trotman
+*/
+#pragma once
+
+#include <stdint.h>
+#include <string.h>
+#include <immintrin.h>
+
+#include "compress_integer_variable_byte.h"
+
+namespace JASS
+	{
+	/*
+		CLASS COMPRESS_INTEGER_ELIAS_GAMMA_SIMD_VB
+		------------------------------------------
+	*/
+	/*!
+		@brief Pack 32-bit integers into 512-bit SIMD words using elias gamma with vbyte for short lists
+		@details see:
+		A. Trotman, K. Lilly (2018), Elias Revisited: Group Elias SIMD Coding,
+		Proceedings of The 23rd Australasian Document Computing Symposium (ADCS 2018)
+	*/
+	class compress_integer_elias_gamma_simd_vb: public compress_integer_variable_byte
+		{
+		protected:
+			static const uint32_t mask_set[33][16];
+
+		protected:
+			/*
+				COMPRESS_INTEGER_ELIAS_GAMMA_SIMD_VB::COMPUTE_SELECTOR()
+				--------------------------------------------------------
+			*/
+			/*!
+				@brief Computer the selector to use for this encoding.
+				@param encodings [in] The width (in bits) of the (at most) 32 integers.  The first integer is at encodngs[0].  leading 0s are used to mark fewer than 32 integers.
+				@return The selector encoded as an integer
+			*/
+			static uint32_t compute_selector(const uint8_t *encodings);
+
+			/*
+				COMPRESS_INTEGER_ELIAS_GAMMA_SIMD_VB::FIND_FIRST_SET_BIT()
+				----------------------------------------------------------
+			*/
+			/*!
+				@brief return the position of the least significant set bit (using a single machine code instruction)
+				@param [in] value the integer to check.
+				@return The position of the lowest set bit (or 0 if no bits are set)
+			*/
+			static inline uint64_t find_first_set_bit(uint64_t value)
+				{
+				return _tzcnt_u64(value) + 1;
+				}
+
+		public:
+			/*
+				COMPRESS_INTEGER_ELIAS_GAMMA_SIMD_VB::ENCODE()
+				----------------------------------------------
+			*/
+			/*!
+				@brief Encode a sequence of integers returning the number of bytes used for the encoding, or 0 if the encoded sequence doesn't fit in the buffer.
+				@param encoded [out] The sequence of bytes that is the encoded sequence.
+				@param encoded_buffer_length [in] The length (in bytes) of the output buffer, encoded.
+				@param source [in] The sequence of integers to encode.
+				@param source_integers [in] The length (in integers) of the source buffer.
+				@return The number of bytes used to encode the integer sequence, or 0 on error (i.e. overflow).
+			*/
+			virtual size_t encode(void *encoded, size_t encoded_buffer_length, const integer *source, size_t source_integers);
+
+			/*
+				COMPRESS_INTEGER_ELIAS_GAMMA_SIMD_VB::DECODE()
+				----------------------------------------------
+			*/
+			/*!
+				@brief Decode a sequence of integers encoded with this codex.
+				@param decoded [out] The sequence of decoded integers.
+				@param integers_to_decode [in] The minimum number of integers to decode (it may decode more).
+				@param source [in] The encoded integers.
+				@param source_length [in] The length (in bytes) of the source buffer.
+			*/
+			virtual void decode(integer *decoded, size_t integers_to_decode, const void *source, size_t source_length);
+
+
+			virtual void encodeArray(const uint32_t *in, uint64_t len, uint32_t *out, uint64_t *nvalue)
+				{
+				*nvalue = encode((void *)out, *nvalue, in, len);			// return the compressed size  (in bytes)
+				}
+			virtual void decodeArray(const uint32_t *in, uint64_t len, uint32_t *out, uint64_t nvalue)
+				{
+				}
+		};
+	}
+
+

--- a/compress_integer_variable_byte.cpp
+++ b/compress_integer_variable_byte.cpp
@@ -1,0 +1,50 @@
+/*
+	COMPRESS_INTEGER_VARIABLE_BYTE.CPP
+	----------------------------------
+	Copyright (c) 2016 Andrew Trotman
+	Released under the 2-clause BSD license (See:https://en.wikipedia.org/wiki/BSD_licenses)
+*/
+#include <string.h>
+#include <stdio.h>
+
+#include "compress_integer_variable_byte.h"
+
+namespace JASS
+	{
+	/*
+		COMPRESS_INTEGER_VARIABLE_BYTE::ENCODE()
+		----------------------------------------
+	*/
+	size_t compress_integer_variable_byte::encode(void *encoded_as_void, size_t encoded_buffer_length, const integer *source, size_t source_integers)
+		{
+		uint8_t *encoded = static_cast<uint8_t *>(encoded_as_void);
+		size_t used = 0;						// the number of bytes of storage used so far
+
+		const integer *end = source + source_integers;			// the end of the input sequence
+		
+		/*
+			Iterate over each integer in the input sequence
+		*/
+		for (const integer *current = source; current < end; current++)
+			{
+			/*
+				find out how much space it'll take
+			*/
+			size_t needed = bytes_needed_for(*current);
+			
+			/*
+				make sure it'll fit in the output buffer
+			*/
+			if (used + needed > encoded_buffer_length)
+				return 0;				// didn't fit so return failure state.
+			
+			/*
+				it fits so encode and add to the size used
+			*/
+			compress_into(encoded, *current);
+			used += needed;
+			}
+
+		return used;
+		}
+	}

--- a/compress_integer_variable_byte.h
+++ b/compress_integer_variable_byte.h
@@ -1,0 +1,394 @@
+/*
+	COMPRESS_INTEGER_VARIABLE_BYTE.H
+	--------------------------------
+	Copyright (c) 2016 Andrew Trotman
+	Released under the 2-clause BSD license (See:https://en.wikipedia.org/wiki/BSD_licenses)
+*/
+/*!
+	@file
+	@brief Variable byte compression for integer sequences.
+	@author Andrew Trotman
+	@copyright 2016 Andrew Trotman
+*/
+#pragma once
+
+#include "compress.h"
+
+namespace JASS
+	{
+	/*
+		CLASS COMPRESS_INTEGER_VARIABLE_BYTE
+		------------------------------------
+	*/
+	/*!
+		@brief Variable byte compression for integer sequences.
+		@details Variable byte compression is a whole suite of different techniques, for details see:
+		A. Trotman (2014), Compression, SIMD, and Postings Lists. In Proceedings of the 2014 Australasian Document Computing Symposium (ADCS 2014), Pages 50-58. DOI=http://dx.doi.org/10.1145/2682862.2682870
+		This particular version uses a stop-bit in the high bit of the last byte of the encoded integer, 
+		stores the integer big-endian (high byte first), and uses loop unwinding for decoding efficiency.
+		The encoding is straight forward.  An integer is broken into 7-bit chunks with the top bit of each
+		chunk being 0, except the last byte which has a 1 in the top bit.  So, the integer 1905 (0x771)
+		is the binary sequence 011101110001, which broken into 7-bit chunks is 0001110 1110001.  These then
+		get the high bits added, 0 for all except the last byte, [0]0001110 [1]1110001, then write out
+		the byte sequence high byte first 0x0E 0xF1.
+		This implementation works with 32-bit and 64-bit integers.  To encode 64-bit integers ensure 
+		\#define JASS_COMPRESS_INTEGER_BITS_PER_INTEGER 64
+		is set at compile time.
+	*/
+	class compress_integer_variable_byte : public ANT_compress
+		{
+		public:
+			/*
+				COMPRESS_INTEGER_VARIABLE_BYTE::COMPRESS_INTEGER_VARIABLE_BYTE()
+				----------------------------------------------------------------
+			*/
+			/*!
+				@brief Constructor.
+			*/
+			compress_integer_variable_byte()
+				{
+				/* Nothing */
+				}
+			
+			/*
+				COMPRESS_INTEGER_VARIABLE_BYTE::~COMPRESS_INTEGER_VARIABLE_BYTE()
+				-----------------------------------------------------------------
+			*/
+			/*!
+				@brief Constructor.
+			*/
+			virtual ~compress_integer_variable_byte()
+				{
+				/* Nothing */
+				}
+
+			/*
+				COMPRESS_INTEGER_VARIABLE_BYTE::ENCODE()
+				----------------------------------------
+			*/
+			/*!
+				@brief Encode a sequence of integers returning the number of bytes used for the encoding, or 0 if the encoded sequence doesn't fit in the buffer.
+				@param encoded [out] The sequence of bytes that is the encoded sequence.
+				@param encoded_buffer_length [in] The length (in bytes) of the output buffer, encoded.
+				@param source [in] The sequence of integers to encode.
+				@param source_integers [in] The length (in integers) of the source buffer.
+				@return The number of bytes used to encode the integer sequence, or 0 on error (i.e. overflow).
+			*/
+			virtual size_t encode(void *encoded, size_t encoded_buffer_length, const integer *source, size_t source_integers);
+			
+			/*
+				COMPRESS_INTEGER_VARIABLE_BYTE::DECODE()
+				----------------------------------------
+			*/
+			/*!
+				@brief Decode a sequence of integers encoded with this codex.
+				@param decoded [out] The sequence of decoded integers.
+				@param integers_to_decode [in] The minimum number of integers to decode (it may decode more).
+				@param source [in] The encoded integers.
+				@param source_length [in] The length (in bytes) of the source buffer.
+			*/
+			virtual void decode(integer *decoded, size_t integers_to_decode, const void *source, size_t source_length)
+				{
+				/*
+					Call through to the static version of this function
+				*/
+				static_decode(decoded, integers_to_decode, source, source_length);
+				}
+
+			/*
+				COMPRESS_INTEGER_VARIABLE_BYTE::STATIC_DECODE()
+				-----------------------------------------------
+			*/
+			/*!
+				@brief Decode a sequence of integers encoded with this codex.
+				@param decoded [out] The sequence of decoded integers.
+				@param integers_to_decode [in] The minimum number of integers to decode (it may decode more).
+				@param source_as_void [in] The encoded integers.
+				@param source_length [in] The length (in bytes) of the source buffer.
+			*/
+			static inline void static_decode(integer *decoded, size_t integers_to_decode, const void *source_as_void, size_t source_length)
+				{
+				const uint8_t *source = static_cast<const uint8_t *>(source_as_void);
+				const uint8_t *end = source + source_length;		// compute the stopping condition
+
+				while (source < end)
+					{
+					decompress_into(decoded, source);
+					decoded++;
+					}
+				}
+
+			/*
+				COMPRESS_INTEGER_VARIABLE_BYTE::DECODE_WITH_WRITER()
+				----------------------------------------------------
+			*/
+			/*!
+				@brief Decode a sequence of integers encoded with this codex, calling add_rsv for each SIMD register
+				@param integers_to_decode [in] The minimum number of integers to decode (it may decode more).
+				@param source [in] The encoded integers.
+				@param source_length [in] The length (in bytes) of the source buffer.
+			*/
+#ifdef SIMD_JASS
+			virtual void decode_with_writer(size_t integers_to_decode, const void *source_as_void, size_t source_length)
+				{
+				const uint8_t *source = static_cast<const uint8_t *>(source_as_void);
+				const uint8_t *end = source + source_length;		// compute the stopping condition
+
+				while (source < end)
+					{
+					integer into;
+					
+					decompress_into(&into, source);
+					add_rsv_d1(into);
+					}
+				}
+#endif
+
+			/*
+				COMPRESS_INTEGER_VARIABLE_BYTE::BYTES_NEEDED_FOR()
+				--------------------------------------------------
+			*/
+			/*!
+				@brief Return the number of bytes necessary to encode the integer value.
+				@param value [in] The value whose encoded size is being computed
+				@return the numner of bytes needed to store the enoding of value.
+			*/
+			static inline size_t bytes_needed_for(integer value)
+				{
+				/*
+					The size can be computed by compairing to a bunch of constants.
+				*/
+				if (value < ((uint64_t)1 << 7))
+					return 1;
+				else if (value < ((uint64_t)1 << 14))
+					return 2;
+				else if (value < ((uint64_t)1 << 21))
+					return 3;
+				else if (value < ((uint64_t)1 << 28))
+					return 4;
+#if JASS_COMPRESS_INTEGER_BITS_PER_INTEGER == 32
+				else
+					return 5;
+#else
+				else if (value < ((uint64_t)1 << 35))
+					return 5;
+				else if (value < ((uint64_t)1 << 42))
+					return 6;
+				else if (value < ((uint64_t)1 << 49))
+					return 7;
+				else if (value < ((uint64_t)1 << 56))
+					return 8;
+				else if (value < ((uint64_t)1 << 63))
+					return 9;
+				else
+					return 10;
+#endif
+				}
+
+			/*
+				COMPRESS_INTEGER_VARIABLE_BYTE::COMPRESS_INTO()
+				-----------------------------------------------
+			*/
+			/*!
+				@brief Encode the given integer placing the encoding into destination (whose size is not validated).
+				@param destination [out] The buffer to write into.
+				@param value [in] The value to encode.
+			*/
+			template <typename DESTINATION>
+			static inline void compress_into(DESTINATION &destination, integer value)
+				{
+				/*
+					Work out how many bytes it'll take to encode
+				*/
+				if (value < ((uint64_t)1 << 7))
+					goto one;
+				else if (value < ((uint64_t)1 << 14))
+					goto two;
+				else if (value < ((uint64_t)1 << 21))
+					goto three;
+				else if (value < ((uint64_t)1 << 28))
+					goto four;
+#if JASS_COMPRESS_INTEGER_BITS_PER_INTEGER == 32
+				goto five;
+#else
+				else if (value < ((uint64_t)1 << 35))
+					goto five;
+				else if (value < ((uint64_t)1 << 42))
+					goto six;
+				else if (value < ((uint64_t)1 << 49))
+					goto seven;
+				else if (value < ((uint64_t)1 << 56))
+					goto eight;
+				else if (value < ((uint64_t)1 << 63))
+					goto nine;
+				else
+					goto ten;
+#endif
+
+				/*
+					Now encode byte at a time with fall-through
+				*/
+#if JASS_COMPRESS_INTEGER_BITS_PER_INTEGER == 64
+				ten:
+					*destination = (value >> 63) & 0x7F;
+					++destination;
+				nine:
+					*destination = (value >> 56) & 0x7F;
+					++destination;
+				eight:
+					*destination = (value >> 49) & 0x7F;
+					++destination;
+				seven:
+					*destination = (value >> 42) & 0x7F;
+					++destination;
+				six:
+					*destination = (value >> 35) & 0x7F;
+					++destination;
+#endif
+				five:
+					*destination = (value >> 28) & 0x7F;
+					++destination;
+				four:
+					*destination = (value >> 21) & 0x7F;
+					++destination;
+				three:
+					*destination = (value >> 14) & 0x7F;
+					++destination;
+				two:
+					*destination = (value >> 7) & 0x7F;
+					++destination;
+				one:
+					*destination = (value & 0x7F) | 0x80;
+					++destination;
+				}
+
+
+			/*
+				COMPRESS_INTEGER_VARIABLE_BYTE::DECOMPRESS_INTO()
+				-------------------------------------------------
+			*/
+			/*!
+				@brief Decode the given integer placing the encoding into destination (whose size is not validated).
+				@param decoded [out] The decoded integer.
+				@param source [in] The buffer to decode from.
+			*/
+			template <typename SOURCE>
+			static inline void decompress_into(integer *decoded, SOURCE &source)
+				{
+				/*
+					If the high bit is set the sequence is over, otherwise, in an unwound loop, decode the integers one at a time.
+				*/
+				if (*source & 0x80)
+					{
+					*decoded = *source & 0x7F;
+					++source;
+					}
+				else
+					{
+					*decoded = *source;
+					++source;
+					if (*source & 0x80)
+						{
+						*decoded = (*decoded << 7) | (*source & 0x7F);
+						++source;
+						}
+					else
+						{
+						*decoded = (*decoded << 7) | *source;
+						++source;
+						if (*source & 0x80)
+							{
+							*decoded = (*decoded << 7) | (*source & 0x7F);
+							++source;
+							}
+						else
+							{
+							*decoded = (*decoded << 7) | *source;
+							++source;
+							if (*source & 0x80)
+								{
+								*decoded = (*decoded << 7) | (*source & 0x7F);
+								++source;
+								}
+							else
+								{
+								*decoded = (*decoded << 7) | *source;
+								++source;
+								if (*source & 0x80)
+									{
+									*decoded = (*decoded << 7) | (*source & 0x7F);
+									++source;
+									}
+								else
+									{
+	#if JASS_COMPRESS_INTEGER_BITS_PER_INTEGER == 64
+									*decoded = (*decoded << 7) | *source;
+									++source;
+									if (*source & 0x80)
+										{
+										*decoded = (*decoded << 7) | (*source & 0x7F);
+										++source;
+										}
+									else
+										{
+										*decoded = (*decoded << 7) | *source;
+										++source;
+										if (*source & 0x80)
+											{
+											*decoded = (*decoded << 7) | (*source & 0x7F);
+											++source;
+											}
+										else
+											{
+											*decoded = (*decoded << 7) | *source;
+											++source;
+											if (*source & 0x80)
+												{
+												*decoded = (*decoded << 7) | (*source & 0x7F);
+												++source;
+												}
+											else
+												{
+												*decoded = (*decoded << 7) | *source;
+												++source;
+												if (*source & 0x80)
+													{
+													*decoded = (*decoded << 7) | (*source & 0x7F);
+													++source;
+													}
+												else
+													{
+													*decoded = (*decoded << 7) | *source;
+													++source;
+													if (*source & 0x80)
+														{
+														*decoded = (*decoded << 7) | (*source & 0x7F);
+														++source;
+														}
+													else
+														{
+														*decoded = (*decoded << 7) | *source;
+														++source;
+														}
+													}
+												}
+											}
+										}
+	#endif
+									}
+								}
+							}
+						}
+					}
+				}
+
+		virtual void encodeArray(const uint32_t *in, uint64_t len, uint32_t *out, uint64_t *nvalue)
+			{
+			*nvalue = encode((void *)out, *nvalue, in, len);			// return the compressed size  (in bytes)
+			}
+		virtual void decodeArray(const uint32_t *in, uint64_t len, uint32_t *out, uint64_t nvalue)
+			{
+			}
+
+		} ;
+}


### PR DESCRIPTION
Hi,

I've added a newer version of the Elias Gamma SIMD that uses v-byte for short lists.  This is the encoding I'm currently using by default.